### PR TITLE
修复使用数字证书加盖甲方的印章后，再用加盖后的PDF文件再加盖乙方的印章，也使用数字证书时，会提示“字段已被使用”的错误

### DIFF
--- a/PDFQFZ/Form1.cs
+++ b/PDFQFZ/Form1.cs
@@ -635,7 +635,7 @@ namespace PDFQFZ
                             //signatureAppearance.Layer2Text = text;
 
                             float bk = 2;//数字签名的图片要加上边框才能跟普通印章的位置完全一致
-                            signatureAppearance.SetVisibleSignature(new iTextSharp.text.Rectangle(xPos- bk, yPos- bk, xPos + imgW + bk, yPos + imgH + bk), signpage, "Signature");
+                            signatureAppearance.SetVisibleSignature(new iTextSharp.text.Rectangle(xPos- bk, yPos- bk, xPos + imgW + bk, yPos + imgH + bk), signpage, null);
                         }
 
                         MakeSignature.SignDetached(signatureAppearance, externalSignature, chain, null, null, null, 0, CryptoStandard.CMS);


### PR DESCRIPTION
修复使用数字证书加盖甲方的印章后，再用加盖后的PDF文件再加盖乙方的印章，也使用数字证书时，会提示“字段已被使用”的错误